### PR TITLE
Fix typos in provider instructions

### DIFF
--- a/providers/wine_mlx_server_unstructured.py
+++ b/providers/wine_mlx_server_unstructured.py
@@ -76,7 +76,7 @@ def call_model(model, prompt):
                         don't add anything else, just the answer in the given format.
                         Don't add json in front of the response.
                         Don't forget key variety in the json result.
-                        Theese are wrong format of answers:
+                        These are wrong format of answers:
                         {"Champagne Blend" : "answer"}
                         {"Grenache"} - missing variety key
                         {"Rosé"} - missing variety key
@@ -242,7 +242,7 @@ def call_model(model, prompt):
                         don't add anything else, just the answer in the given format.
                         Don't add json in front of the response.
                         Don't forget key variety in the json result.
-                        Theese are wrong format of answers:
+                        These are wrong format of answers:
                         {"Champagne Blend" : "answer"}
                         {"Grenache"} - missing variety key
                         {"Rosé"} - missing variety key

--- a/providers/wine_openai_unstructured.py
+++ b/providers/wine_openai_unstructured.py
@@ -75,14 +75,14 @@ def call_model(model, prompt):
                         don't add anything else, just the answer in the given format.
                         Don't add json in front of the response.
                         Don't forget key variety in the json result.
-                        Theese are wrong format of answers:
+                        These are wrong format of answers:
                         {"Champagne Blend" : "answer"}
                         {"Grenache"} - missing variety key
                         {"Rosé"} - missing variety key
                         Good ones are:
                         { "variety": "Chardonnay" }
                         {"variety" : "Bordeaux-style White Blend"}
-                        Here the prompt to analize: 
+                        Here the prompt to analyze: 
                     """
                         + prompt,
                     },


### PR DESCRIPTION
## Summary
- correct typos in instruction text for OpenAI unstructured provider
- correct typos in MLX server unstructured provider

## Testing
- `git status --short`