### PR TITLE
Enable qwen3 training format

### DIFF
--- a/LORA.md
+++ b/LORA.md
@@ -22,6 +22,11 @@ python -m train.generate_data
 python -m train.generate_data --all-countries
 ```
 
+3. Generate data with Qwen3 formatting (adds `/no_think` and `<think>` tags):
+```bash
+python -m train.generate_data --qwen3-format
+```
+
 The script will:
 - Load and filter the wine dataset
 - Remove rare varieties (less than 5 examples)
@@ -74,4 +79,14 @@ Key configuration options in `phi_lora_config_sample.yaml`:
   - Initial warmup steps: 100
   - Learning rate range: 1e-6 to 1e-4
 
-Monitor the training progress through the logged metrics and validation results. 
+Monitor the training progress through the logged metrics and validation results.
+
+### Qwen3 Training
+
+For fine-tuning Qwen3 models, use `train/qwen_lora_config.yaml` and make sure
+your training data was generated with the `--qwen3-format` flag. Start training
+with:
+
+```bash
+mlx_lm.lora --config ./train/qwen_lora_config.yaml
+```

--- a/README.md
+++ b/README.md
@@ -105,6 +105,10 @@ In the providers folder you will find the individual implementations for each pr
 3. Set up your environment variables in `.env` file
 4. Download the dataset and place it in the `data` folder
 5. Run the Jupyter notebook or individual Python scripts
+6. To generate data for Qwen3 fine-tuning use:
+   ```bash
+   python -m train.generate_data --qwen3-format
+   ```
 
 ### Running Individual Providers
 

--- a/train/qwen_lora_config.yaml
+++ b/train/qwen_lora_config.yaml
@@ -2,8 +2,6 @@
 
 # The path to the local model directory or Hugging Face repo.
 model: "mlx-community/Qwen3-1.7B-bf16"
-# Use /no_think prompts with <think> tags
-qwen3_format: true
 # Whether or not to train (boolean)
 # train: true
 

--- a/train/qwen_lora_config.yaml
+++ b/train/qwen_lora_config.yaml
@@ -2,6 +2,8 @@
 
 # The path to the local model directory or Hugging Face repo.
 model: "mlx-community/Qwen3-1.7B-bf16"
+# Use /no_think prompts with <think> tags
+qwen3_format: true
 # Whether or not to train (boolean)
 # train: true
 


### PR DESCRIPTION
## Summary
- add `--qwen3-format` flag to training data generator
- document qwen3 training workflow
- update README usage notes
- mark qwen3 config with `qwen3_format: true`

## Testing
- `python -m py_compile train/generate_data.py`
