### PR TITLE
Add per-row result logging across providers

### DIFF
--- a/providers/wine_anthropic.py
+++ b/providers/wine_anthropic.py
@@ -78,7 +78,14 @@ def process_example(index, row, model, df, progress_bar):
         # Generate the prompt using the row
         prompt = generate_prompt(row, varieties)
 
-        df.at[index, model + "-variety"] = call_model(model, prompt)
+        predicted_variety = call_model(model, prompt)
+        df.at[index, model + "-variety"] = predicted_variety
+
+        actual_variety = row["variety"]
+        if predicted_variety == actual_variety:
+            tqdm.write(f"✅ Predicted: {predicted_variety}, Actual: {actual_variety}")
+        else:
+            tqdm.write(f"❌ Predicted: {predicted_variety}, Actual: {actual_variety}")
 
         # Update the progress bar
         progress_bar.update(1)

--- a/providers/wine_deepseek.py
+++ b/providers/wine_deepseek.py
@@ -79,7 +79,14 @@ def process_example(index, row, model, df, progress_bar):
         # Generate the prompt using the row
         prompt = generate_prompt(row, varieties)
 
-        df.at[index, model + "-variety"] = call_model(model, prompt)
+        predicted_variety = call_model(model, prompt)
+        df.at[index, model + "-variety"] = predicted_variety
+
+        actual_variety = row["variety"]
+        if predicted_variety == actual_variety:
+            tqdm.write(f"✅ Predicted: {predicted_variety}, Actual: {actual_variety}")
+        else:
+            tqdm.write(f"❌ Predicted: {predicted_variety}, Actual: {actual_variety}")
 
         # Update the progress bar
         progress_bar.update(1)

--- a/providers/wine_gemini.py
+++ b/providers/wine_gemini.py
@@ -102,7 +102,14 @@ def process_example(index, row, model, df, progress_bar):
         # Generate the prompt using the row
         prompt = generate_prompt(row, varieties)
 
-        df.at[index, model + "-variety"] = call_model(model, prompt)
+        predicted_variety = call_model(model, prompt)
+        df.at[index, model + "-variety"] = predicted_variety
+
+        actual_variety = row["variety"]
+        if predicted_variety == actual_variety:
+            tqdm.write(f"✅ Predicted: {predicted_variety}, Actual: {actual_variety}")
+        else:
+            tqdm.write(f"❌ Predicted: {predicted_variety}, Actual: {actual_variety}")
 
         # Update the progress bar
         progress_bar.update(1)

--- a/providers/wine_gemini_genai.py
+++ b/providers/wine_gemini_genai.py
@@ -108,7 +108,14 @@ def process_example(index, row, model, df, progress_bar):
         # Generate the prompt using the row
         prompt = generate_prompt(row, varieties)
 
-        df.at[index, model + "-variety"] = call_model(model, prompt)
+        predicted_variety = call_model(model, prompt)
+        df.at[index, model + "-variety"] = predicted_variety
+
+        actual_variety = row["variety"]
+        if predicted_variety == actual_variety:
+            tqdm.write(f"✅ Predicted: {predicted_variety}, Actual: {actual_variety}")
+        else:
+            tqdm.write(f"❌ Predicted: {predicted_variety}, Actual: {actual_variety}")
 
         # Update the progress bar
         progress_bar.update(1)

--- a/providers/wine_gemini_openai.py
+++ b/providers/wine_gemini_openai.py
@@ -88,7 +88,14 @@ def process_example(index, row, model, df, progress_bar):
         # Generate the prompt using the row
         prompt = generate_prompt(row, varieties)
 
-        df.at[index, model + "-variety"] = call_model(model, prompt)
+        predicted_variety = call_model(model, prompt)
+        df.at[index, model + "-variety"] = predicted_variety
+
+        actual_variety = row["variety"]
+        if predicted_variety == actual_variety:
+            tqdm.write(f"✅ Predicted: {predicted_variety}, Actual: {actual_variety}")
+        else:
+            tqdm.write(f"❌ Predicted: {predicted_variety}, Actual: {actual_variety}")
 
         # Update the progress bar
         progress_bar.update(1)

--- a/providers/wine_lmstudio.py
+++ b/providers/wine_lmstudio.py
@@ -74,7 +74,14 @@ def process_example(index, row, model, df, progress_bar):
         # Generate the prompt using the row
         prompt = generate_prompt(row, varieties)
 
-        df.at[index, model + "-variety"] = call_model(model, prompt)
+        predicted_variety = call_model(model, prompt)
+        df.at[index, model + "-variety"] = predicted_variety
+
+        actual_variety = row["variety"]
+        if predicted_variety == actual_variety:
+            tqdm.write(f"✅ Predicted: {predicted_variety}, Actual: {actual_variety}")
+        else:
+            tqdm.write(f"❌ Predicted: {predicted_variety}, Actual: {actual_variety}")
 
         # Update the progress bar
         progress_bar.update(1)

--- a/providers/wine_mlx_omni_server.py
+++ b/providers/wine_mlx_omni_server.py
@@ -89,7 +89,14 @@ def process_example(index, row, model, df, progress_bar):
         # Generate the prompt using the row
         prompt = generate_prompt(row, varieties)
 
-        df.at[index, model + "-variety"] = call_model(model, prompt)
+        predicted_variety = call_model(model, prompt)
+        df.at[index, model + "-variety"] = predicted_variety
+
+        actual_variety = row["variety"]
+        if predicted_variety == actual_variety:
+            tqdm.write(f"✅ Predicted: {predicted_variety}, Actual: {actual_variety}")
+        else:
+            tqdm.write(f"❌ Predicted: {predicted_variety}, Actual: {actual_variety}")
 
         # Update the progress bar
         progress_bar.update(1)

--- a/providers/wine_ollama.py
+++ b/providers/wine_ollama.py
@@ -58,7 +58,14 @@ def process_example(index, row, model, df, progress_bar):
         # Generate the prompt using the row
         prompt = generate_prompt(row, varieties)
 
-        df.at[index, model + "-variety"] = call_model(model, prompt)
+        predicted_variety = call_model(model, prompt)
+        df.at[index, model + "-variety"] = predicted_variety
+
+        actual_variety = row["variety"]
+        if predicted_variety == actual_variety:
+            tqdm.write(f"✅ Predicted: {predicted_variety}, Actual: {actual_variety}")
+        else:
+            tqdm.write(f"❌ Predicted: {predicted_variety}, Actual: {actual_variety}")
 
         # Update the progress bar
         progress_bar.update(1)

--- a/providers/wine_openai.py
+++ b/providers/wine_openai.py
@@ -98,7 +98,14 @@ def process_example(index, row, model, df, progress_bar):
         # Generate the prompt using the row
         prompt = generate_prompt(row, varieties)
 
-        df.at[index, model + "-variety"] = call_model(model, prompt)
+        predicted_variety = call_model(model, prompt)
+        df.at[index, model + "-variety"] = predicted_variety
+
+        actual_variety = row["variety"]
+        if predicted_variety == actual_variety:
+            tqdm.write(f"✅ Predicted: {predicted_variety}, Actual: {actual_variety}")
+        else:
+            tqdm.write(f"❌ Predicted: {predicted_variety}, Actual: {actual_variety}")
 
         # Update the progress bar
         progress_bar.update(1)

--- a/providers/wine_openai_batching.py
+++ b/providers/wine_openai_batching.py
@@ -97,6 +97,12 @@ def process_batch_results(df, results, model):
         )["variety"]
         df.at[index, f"{model}-variety"] = variety
 
+        actual_variety = df.at[index, "variety"]
+        if variety == actual_variety:
+            tqdm.write(f"✅ Predicted: {variety}, Actual: {actual_variety}")
+        else:
+            tqdm.write(f"❌ Predicted: {variety}, Actual: {actual_variety}")
+
     return df
 
 

--- a/providers/wine_openai_unstructured.py
+++ b/providers/wine_openai_unstructured.py
@@ -91,7 +91,14 @@ def process_example(index, row, model, df, progress_bar):
         # Generate the prompt using the row
         prompt = generate_prompt(row, varieties)
 
-        df.at[index, model + "-variety"] = call_model(model, prompt)
+        predicted_variety = call_model(model, prompt)
+        df.at[index, model + "-variety"] = predicted_variety
+
+        actual_variety = row["variety"]
+        if predicted_variety == actual_variety:
+            tqdm.write(f"✅ Predicted: {predicted_variety}, Actual: {actual_variety}")
+        else:
+            tqdm.write(f"❌ Predicted: {predicted_variety}, Actual: {actual_variety}")
 
         # Update the progress bar
         progress_bar.update(1)

--- a/providers/wine_openrouter.py
+++ b/providers/wine_openrouter.py
@@ -99,6 +99,13 @@ def process_example(index, row, model, df, progress_bar):
         prompt = generate_prompt(row, varieties)
         result = call_model(model, prompt)
         df.at[index, model + "-variety"] = result
+
+        actual_variety = row["variety"]
+        if result == actual_variety:
+            tqdm.write(f"✅ Predicted: {result}, Actual: {actual_variety}")
+        else:
+            tqdm.write(f"❌ Predicted: {result}, Actual: {actual_variety}")
+
         progress_bar.update(1)
     except Exception as e:
         print(f"Error processing example {index}: {str(e)}")


### PR DESCRIPTION
## Summary
- replicate detailed row progress printing from `wine_mlx_server_unstructured`
- update all provider modules to show ✅/❌ per row

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*