### PR TITLE
Sync prompt generation

### DIFF
--- a/providers/wine_deepseek.py
+++ b/providers/wine_deepseek.py
@@ -10,6 +10,33 @@ import concurrent.futures
 from data_utils import prepare_wine_data
 from config import COUNTRY, SAMPLE_SIZE, RANDOM_SEED
 
+# Global variable to store data from JSONL file
+jsonl_data = []
+
+# Function to load data from JSONL file
+def load_jsonl_data(file_path="./train/data/test.jsonl"):
+    data = []
+    try:
+        with open(file_path, 'r') as f:
+            for line in f:
+                try:
+                    data.append(json.loads(line))
+                except json.JSONDecodeError as e:
+                    print(
+                        f"Warning: Skipping malformed JSON line in {file_path}: {line.strip()} - Error: {e}"
+                    )
+        if not data:
+            print(
+                f"Warning: No data loaded from {file_path}. File might be empty or all lines were malformed."
+            )
+        return data
+    except FileNotFoundError:
+        print(f"Error: {file_path} not found. Please ensure the file exists in the correct location.")
+        return []  # Return empty list if file not found
+    except Exception as e:
+        print(f"An unexpected error occurred while loading {file_path}: {e}")
+        return []
+
 # Define default models
 DEFAULT_MODELS = ["deepseek-chat"]
 
@@ -27,23 +54,22 @@ np.random.seed(RANDOM_SEED)
 # Load and prepare the dataset
 df_country_subset, varieties = prepare_wine_data()
 
+# Load data from JSONL file at the beginning
+jsonl_data = load_jsonl_data()
 
-def generate_prompt(row, varieties):
-    # Format the varieties list as a comma-separated string
-    variety_list = ", ".join(varieties)
 
-    prompt = f"""
-    Based on this wine review, guess the grape variety:
-    This wine is produced by {row['winery']} in the {row['province']} region of {row['country']}.
-    It was grown in {row['region_1']}. It is described as: "{row['description']}".
-    The wine has been reviewed by {row['taster_name']} and received {row['points']} points.
-    The price is {row['price']}.
+def generate_prompt(index):
+    """Generates a prompt using the entry at the given index from the loaded JSONL data."""
+    if not jsonl_data:
+        raise ValueError("JSONL data is not loaded or is empty.")
+    if index >= len(jsonl_data):
+        raise IndexError(f"Index {index} is out of bounds for JSONL data with length {len(jsonl_data)}.")
 
-    Here is a list of possible grape varieties to choose from: {variety_list}.
-    
-    What is the likely grape variety? Answer only with the grape variety name or blend from the list.
-    """
-    return prompt
+    entry = jsonl_data[index]
+    if "prompt" not in entry:
+        raise KeyError(f"Key 'prompt' not found in JSONL data at index {index}.")
+
+    return entry["prompt"]
 
 
 # Function to call the API and process the result for a single model (blocking call in this case)

--- a/providers/wine_gemini.py
+++ b/providers/wine_gemini.py
@@ -9,6 +9,33 @@ from data_utils import prepare_wine_data
 import google.generativeai as genai
 from config import COUNTRY, SAMPLE_SIZE, RANDOM_SEED
 
+# Global variable to store data from JSONL file
+jsonl_data = []
+
+# Function to load data from JSONL file
+def load_jsonl_data(file_path="./train/data/test.jsonl"):
+    data = []
+    try:
+        with open(file_path, 'r') as f:
+            for line in f:
+                try:
+                    data.append(json.loads(line))
+                except json.JSONDecodeError as e:
+                    print(
+                        f"Warning: Skipping malformed JSON line in {file_path}: {line.strip()} - Error: {e}"
+                    )
+        if not data:
+            print(
+                f"Warning: No data loaded from {file_path}. File might be empty or all lines were malformed."
+            )
+        return data
+    except FileNotFoundError:
+        print(f"Error: {file_path} not found. Please ensure the file exists in the correct location.")
+        return []  # Return empty list if file not found
+    except Exception as e:
+        print(f"An unexpected error occurred while loading {file_path}: {e}")
+        return []
+
 # Define default models
 DEFAULT_MODELS = ["gemini-2.5-pro-preview-03-25"]
 
@@ -24,23 +51,22 @@ np.random.seed(RANDOM_SEED)
 # Load and prepare the dataset
 df_country_subset, varieties = prepare_wine_data()
 
+# Load data from JSONL file at the beginning
+jsonl_data = load_jsonl_data()
 
-def generate_prompt(row, varieties):
-    # Format the varieties list as a comma-separated string
-    variety_list = ", ".join(varieties)
 
-    prompt = f"""
-    Based on this wine review, guess the grape variety:
-    This wine is produced by {row['winery']} in the {row['province']} region of {row['country']}.
-    It was grown in {row['region_1']}. It is described as: "{row['description']}".
-    The wine has been reviewed by {row['taster_name']} and received {row['points']} points.
-    The price is {row['price']}.
+def generate_prompt(index):
+    """Generates a prompt using the entry at the given index from the loaded JSONL data."""
+    if not jsonl_data:
+        raise ValueError("JSONL data is not loaded or is empty.")
+    if index >= len(jsonl_data):
+        raise IndexError(f"Index {index} is out of bounds for JSONL data with length {len(jsonl_data)}.")
 
-    Here is a list of possible grape varieties to choose from: {variety_list}.
-    
-    What is the likely grape variety? Answer only with the grape variety name or blend from the list.
-    """
-    return prompt
+    entry = jsonl_data[index]
+    if "prompt" not in entry:
+        raise KeyError(f"Key 'prompt' not found in JSONL data at index {index}.")
+
+    return entry["prompt"]
 
 
 # Function to call the API and process the result for a single model

--- a/providers/wine_gemini_genai.py
+++ b/providers/wine_gemini_genai.py
@@ -11,6 +11,33 @@ from google.genai import types
 from pydantic import BaseModel, Field
 from config import COUNTRY, SAMPLE_SIZE, RANDOM_SEED
 
+# Global variable to store data from JSONL file
+jsonl_data = []
+
+# Function to load data from JSONL file
+def load_jsonl_data(file_path="./train/data/test.jsonl"):
+    data = []
+    try:
+        with open(file_path, 'r') as f:
+            for line in f:
+                try:
+                    data.append(json.loads(line))
+                except json.JSONDecodeError as e:
+                    print(
+                        f"Warning: Skipping malformed JSON line in {file_path}: {line.strip()} - Error: {e}"
+                    )
+        if not data:
+            print(
+                f"Warning: No data loaded from {file_path}. File might be empty or all lines were malformed."
+            )
+        return data
+    except FileNotFoundError:
+        print(f"Error: {file_path} not found. Please ensure the file exists in the correct location.")
+        return []  # Return empty list if file not found
+    except Exception as e:
+        print(f"An unexpected error occurred while loading {file_path}: {e}")
+        return []
+
 # Define default models
 DEFAULT_MODELS = ["gemini-1.5-flash", "gemini-1.5-flash-8b", "gemini-1.5-pro"]
 
@@ -25,23 +52,22 @@ np.random.seed(RANDOM_SEED)
 # Load and prepare the dataset
 df_country_subset, varieties = prepare_wine_data()
 
+# Load data from JSONL file at the beginning
+jsonl_data = load_jsonl_data()
 
-def generate_prompt(row, varieties):
-    # Format the varieties list as a comma-separated string
-    variety_list = ", ".join(varieties)
 
-    prompt = f"""
-    Based on this wine review, guess the grape variety:
-    This wine is produced by {row['winery']} in the {row['province']} region of {row['country']}.
-    It was grown in {row['region_1']}. It is described as: "{row['description']}".
-    The wine has been reviewed by {row['taster_name']} and received {row['points']} points.
-    The price is {row['price']}.
+def generate_prompt(index):
+    """Generates a prompt using the entry at the given index from the loaded JSONL data."""
+    if not jsonl_data:
+        raise ValueError("JSONL data is not loaded or is empty.")
+    if index >= len(jsonl_data):
+        raise IndexError(f"Index {index} is out of bounds for JSONL data with length {len(jsonl_data)}.")
 
-    Here is a list of possible grape varieties to choose from: {variety_list}.
-    
-    What is the likely grape variety? Answer only with the grape variety name or blend from the list.
-    """
-    return prompt
+    entry = jsonl_data[index]
+    if "prompt" not in entry:
+        raise KeyError(f"Key 'prompt' not found in JSONL data at index {index}.")
+
+    return entry["prompt"]
 
 
 class WineVariety(BaseModel):

--- a/providers/wine_lmstudio.py
+++ b/providers/wine_lmstudio.py
@@ -5,6 +5,33 @@ import numpy as np
 from data_utils import prepare_wine_data
 from config import COUNTRY, SAMPLE_SIZE, RANDOM_SEED
 
+# Global variable to store data from JSONL file
+jsonl_data = []
+
+# Function to load data from JSONL file
+def load_jsonl_data(file_path="./train/data/test.jsonl"):
+    data = []
+    try:
+        with open(file_path, 'r') as f:
+            for line in f:
+                try:
+                    data.append(json.loads(line))
+                except json.JSONDecodeError as e:
+                    print(
+                        f"Warning: Skipping malformed JSON line in {file_path}: {line.strip()} - Error: {e}"
+                    )
+        if not data:
+            print(
+                f"Warning: No data loaded from {file_path}. File might be empty or all lines were malformed."
+            )
+        return data
+    except FileNotFoundError:
+        print(f"Error: {file_path} not found. Please ensure the file exists in the correct location.")
+        return []  # Return empty list if file not found
+    except Exception as e:
+        print(f"An unexpected error occurred while loading {file_path}: {e}")
+        return []
+
 # Define default models for LMStudio provider
 DEFAULT_MODELS = ["phi-4"]
 
@@ -16,23 +43,22 @@ client = OpenAI(base_url="http://localhost:1234/v1", api_key="secret")
 # Load and prepare the dataset
 df_country_subset, varieties = prepare_wine_data()
 
+# Load data from JSONL file at the beginning
+jsonl_data = load_jsonl_data()
 
-def generate_prompt(row, varieties):
-    # Format the varieties list as a comma-separated string
-    variety_list = ", ".join(varieties)
 
-    prompt = f"""
-    Based on this wine review, guess the grape variety:
-    This wine is produced by {row['winery']} in the {row['province']} region of {row['country']}.
-    It was grown in {row['region_1']}. It is described as: "{row['description']}".
-    The wine has been reviewed by {row['taster_name']} and received {row['points']} points.
-    The price is {row['price']}.
+def generate_prompt(index):
+    """Generates a prompt using the entry at the given index from the loaded JSONL data."""
+    if not jsonl_data:
+        raise ValueError("JSONL data is not loaded or is empty.")
+    if index >= len(jsonl_data):
+        raise IndexError(f"Index {index} is out of bounds for JSONL data with length {len(jsonl_data)}.")
 
-    Here is a list of possible grape varieties to choose from: {variety_list}.
-    
-    What is the likely grape variety? Answer only with the grape variety name or blend from the list.
-    """
-    return prompt
+    entry = jsonl_data[index]
+    if "prompt" not in entry:
+        raise KeyError(f"Key 'prompt' not found in JSONL data at index {index}.")
+
+    return entry["prompt"]
 
 
 response_format = {

--- a/providers/wine_mlx_omni_server.py
+++ b/providers/wine_mlx_omni_server.py
@@ -6,6 +6,33 @@ from data_utils import prepare_wine_data
 import argparse
 from config import COUNTRY, SAMPLE_SIZE, RANDOM_SEED
 
+# Global variable to store data from JSONL file
+jsonl_data = []
+
+# Function to load data from JSONL file
+def load_jsonl_data(file_path="./train/data/test.jsonl"):
+    data = []
+    try:
+        with open(file_path, 'r') as f:
+            for line in f:
+                try:
+                    data.append(json.loads(line))
+                except json.JSONDecodeError as e:
+                    print(
+                        f"Warning: Skipping malformed JSON line in {file_path}: {line.strip()} - Error: {e}"
+                    )
+        if not data:
+            print(
+                f"Warning: No data loaded from {file_path}. File might be empty or all lines were malformed."
+            )
+        return data
+    except FileNotFoundError:
+        print(f"Error: {file_path} not found. Please ensure the file exists in the correct location.")
+        return []  # Return empty list if file not found
+    except Exception as e:
+        print(f"An unexpected error occurred while loading {file_path}: {e}")
+        return []
+
 # Parse command line arguments
 parser = argparse.ArgumentParser(
     description="Wine variety classification using MLX Omni Server"
@@ -24,23 +51,22 @@ client = OpenAI(base_url="http://localhost:10240/v1", api_key="not-needed")
 # Load and prepare the dataset
 df_country_subset, varieties = prepare_wine_data()
 
+# Load data from JSONL file at the beginning
+jsonl_data = load_jsonl_data()
 
-def generate_prompt(row, varieties):
-    # Format the varieties list as a comma-separated string
-    variety_list = ", ".join(varieties)
 
-    prompt = f"""
-    Based on this wine review, guess the grape variety:
-    This wine is produced by {row['winery']} in the {row['province']} region of {row['country']}.
-    It was grown in {row['region_1']}. It is described as: "{row['description']}".
-    The wine has been reviewed by {row['taster_name']} and received {row['points']} points.
-    The price is {row['price']}.
+def generate_prompt(index):
+    """Generates a prompt using the entry at the given index from the loaded JSONL data."""
+    if not jsonl_data:
+        raise ValueError("JSONL data is not loaded or is empty.")
+    if index >= len(jsonl_data):
+        raise IndexError(f"Index {index} is out of bounds for JSONL data with length {len(jsonl_data)}.")
 
-    Here is a list of possible grape varieties to choose from: {variety_list}.
-    
-    What is the likely grape variety? Answer only with the grape variety name or blend from the list.
-    """
-    return prompt
+    entry = jsonl_data[index]
+    if "prompt" not in entry:
+        raise KeyError(f"Key 'prompt' not found in JSONL data at index {index}.")
+
+    return entry["prompt"]
 
 
 response_format = {

--- a/providers/wine_ollama.py
+++ b/providers/wine_ollama.py
@@ -5,29 +5,55 @@ from data_utils import prepare_wine_data
 from pydantic import BaseModel, Field
 from config import COUNTRY, SAMPLE_SIZE, RANDOM_SEED
 
+# Global variable to store data from JSONL file
+jsonl_data = []
+
+# Function to load data from JSONL file
+def load_jsonl_data(file_path="./train/data/test.jsonl"):
+    data = []
+    try:
+        with open(file_path, 'r') as f:
+            for line in f:
+                try:
+                    data.append(json.loads(line))
+                except json.JSONDecodeError as e:
+                    print(
+                        f"Warning: Skipping malformed JSON line in {file_path}: {line.strip()} - Error: {e}"
+                    )
+        if not data:
+            print(
+                f"Warning: No data loaded from {file_path}. File might be empty or all lines were malformed."
+            )
+        return data
+    except FileNotFoundError:
+        print(f"Error: {file_path} not found. Please ensure the file exists in the correct location.")
+        return []  # Return empty list if file not found
+    except Exception as e:
+        print(f"An unexpected error occurred while loading {file_path}: {e}")
+        return []
+
 # Set random seed for reproducibility
 np.random.seed(RANDOM_SEED)
 
 # Load and prepare the dataset
 df_country_subset, varieties = prepare_wine_data()
 
+# Load data from JSONL file at the beginning
+jsonl_data = load_jsonl_data()
 
-def generate_prompt(row, varieties):
-    # Format the varieties list as a comma-separated string
-    variety_list = ", ".join(varieties)
 
-    prompt = f"""
-    Based on this wine review, guess the grape variety:
-    This wine is produced by {row['winery']} in the {row['province']} region of {row['country']}.
-    It was grown in {row['region_1']}. It is described as: "{row['description']}".
-    The wine has been reviewed by {row['taster_name']} and received {row['points']} points.
-    The price is {row['price']}.
+def generate_prompt(index):
+    """Generates a prompt using the entry at the given index from the loaded JSONL data."""
+    if not jsonl_data:
+        raise ValueError("JSONL data is not loaded or is empty.")
+    if index >= len(jsonl_data):
+        raise IndexError(f"Index {index} is out of bounds for JSONL data with length {len(jsonl_data)}.")
 
-    Here is a list of possible grape varieties to choose from: {variety_list}.
-    
-    What is the likely grape variety? Answer only with the grape variety name or blend from the list.
-    """
-    return prompt
+    entry = jsonl_data[index]
+    if "prompt" not in entry:
+        raise KeyError(f"Key 'prompt' not found in JSONL data at index {index}.")
+
+    return entry["prompt"]
 
 
 class WineVariety(BaseModel):

--- a/providers/wine_openai.py
+++ b/providers/wine_openai.py
@@ -10,6 +10,33 @@ from data_utils import prepare_wine_data
 from dotenv import load_dotenv
 from config import COUNTRY, SAMPLE_SIZE, RANDOM_SEED
 
+# Global variable to store data from JSONL file
+jsonl_data = []
+
+# Function to load data from JSONL file
+def load_jsonl_data(file_path="./train/data/test.jsonl"):
+    data = []
+    try:
+        with open(file_path, 'r') as f:
+            for line in f:
+                try:
+                    data.append(json.loads(line))
+                except json.JSONDecodeError as e:
+                    print(
+                        f"Warning: Skipping malformed JSON line in {file_path}: {line.strip()} - Error: {e}"
+                    )
+        if not data:
+            print(
+                f"Warning: No data loaded from {file_path}. File might be empty or all lines were malformed."
+            )
+        return data
+    except FileNotFoundError:
+        print(f"Error: {file_path} not found. Please ensure the file exists in the correct location.")
+        return []  # Return empty list if file not found
+    except Exception as e:
+        print(f"An unexpected error occurred while loading {file_path}: {e}")
+        return []
+
 # Define default models
 DEFAULT_MODELS = ["gpt-4.1-mini", "gpt-4.1-nano"]
 
@@ -24,23 +51,22 @@ np.random.seed(RANDOM_SEED)
 # Load and prepare the dataset
 df_country_subset, varieties = prepare_wine_data()
 
+# Load data from JSONL file at the beginning
+jsonl_data = load_jsonl_data()
 
-def generate_prompt(row, varieties):
-    # Format the varieties list as a comma-separated string
-    variety_list = ", ".join(varieties)
 
-    prompt = f"""
-    Based on this wine review, guess the grape variety:
-    This wine is produced by {row['winery']} in the {row['province']} region of {row['country']}.
-    It was grown in {row['region_1']}. It is described as: "{row['description']}".
-    The wine has been reviewed by {row['taster_name']} and received {row['points']} points.
-    The price is {row['price']}.
+def generate_prompt(index):
+    """Generates a prompt using the entry at the given index from the loaded JSONL data."""
+    if not jsonl_data:
+        raise ValueError("JSONL data is not loaded or is empty.")
+    if index >= len(jsonl_data):
+        raise IndexError(f"Index {index} is out of bounds for JSONL data with length {len(jsonl_data)}.")
 
-    Here is a list of possible grape varieties to choose from: {variety_list}.
-    
-    What is the likely grape variety? Answer only with the grape variety name or blend from the list.
-    """
-    return prompt
+    entry = jsonl_data[index]
+    if "prompt" not in entry:
+        raise KeyError(f"Key 'prompt' not found in JSONL data at index {index}.")
+
+    return entry["prompt"]
 
 
 response_format = {

--- a/providers/wine_openai_batching.py
+++ b/providers/wine_openai_batching.py
@@ -10,6 +10,33 @@ from datetime import datetime
 from dotenv import load_dotenv
 from config import COUNTRY, SAMPLE_SIZE, RANDOM_SEED
 
+# Global variable to store data from JSONL file
+jsonl_data = []
+
+# Function to load data from JSONL file
+def load_jsonl_data(file_path="./train/data/test.jsonl"):
+    data = []
+    try:
+        with open(file_path, 'r') as f:
+            for line in f:
+                try:
+                    data.append(json.loads(line))
+                except json.JSONDecodeError as e:
+                    print(
+                        f"Warning: Skipping malformed JSON line in {file_path}: {line.strip()} - Error: {e}"
+                    )
+        if not data:
+            print(
+                f"Warning: No data loaded from {file_path}. File might be empty or all lines were malformed."
+            )
+        return data
+    except FileNotFoundError:
+        print(f"Error: {file_path} not found. Please ensure the file exists in the correct location.")
+        return []  # Return empty list if file not found
+    except Exception as e:
+        print(f"An unexpected error occurred while loading {file_path}: {e}")
+        return []
+
 # Define default models
 DEFAULT_MODELS = ["gpt-4o-mini"]
 
@@ -24,23 +51,22 @@ np.random.seed(RANDOM_SEED)
 # Load and prepare the dataset
 df_country_subset, varieties = prepare_wine_data()
 
+# Load data from JSONL file at the beginning
+jsonl_data = load_jsonl_data()
 
-def generate_prompt(row, varieties):
-    # Format the varieties list as a comma-separated string
-    variety_list = ", ".join(varieties)
 
-    prompt = f"""
-    Based on this wine review, guess the grape variety:
-    This wine is produced by {row['winery']} in the {row['province']} region of {row['country']}.
-    It was grown in {row['region_1']}. It is described as: "{row['description']}".
-    The wine has been reviewed by {row['taster_name']} and received {row['points']} points.
-    The price is {row['price']}.
+def generate_prompt(index):
+    """Generates a prompt using the entry at the given index from the loaded JSONL data."""
+    if not jsonl_data:
+        raise ValueError("JSONL data is not loaded or is empty.")
+    if index >= len(jsonl_data):
+        raise IndexError(f"Index {index} is out of bounds for JSONL data with length {len(jsonl_data)}.")
 
-    Here is a list of possible grape varieties to choose from: {variety_list}.
-    
-    What is the likely grape variety? Answer only with the grape variety name or blend from the list.
-    """
-    return prompt
+    entry = jsonl_data[index]
+    if "prompt" not in entry:
+        raise KeyError(f"Key 'prompt' not found in JSONL data at index {index}.")
+
+    return entry["prompt"]
 
 
 response_format = {

--- a/providers/wine_openai_unstructured.py
+++ b/providers/wine_openai_unstructured.py
@@ -10,6 +10,33 @@ from data_utils import prepare_wine_data
 from dotenv import load_dotenv
 from config import COUNTRY, SAMPLE_SIZE, RANDOM_SEED
 
+# Global variable to store data from JSONL file
+jsonl_data = []
+
+# Function to load data from JSONL file
+def load_jsonl_data(file_path="./train/data/test.jsonl"):
+    data = []
+    try:
+        with open(file_path, 'r') as f:
+            for line in f:
+                try:
+                    data.append(json.loads(line))
+                except json.JSONDecodeError as e:
+                    print(
+                        f"Warning: Skipping malformed JSON line in {file_path}: {line.strip()} - Error: {e}"
+                    )
+        if not data:
+            print(
+                f"Warning: No data loaded from {file_path}. File might be empty or all lines were malformed."
+            )
+        return data
+    except FileNotFoundError:
+        print(f"Error: {file_path} not found. Please ensure the file exists in the correct location.")
+        return []  # Return empty list if file not found
+    except Exception as e:
+        print(f"An unexpected error occurred while loading {file_path}: {e}")
+        return []
+
 # Define default models
 DEFAULT_MODELS = ["gpt-4o-mini"]
 
@@ -24,23 +51,22 @@ np.random.seed(RANDOM_SEED)
 # Load and prepare the dataset
 df_country_subset, varieties = prepare_wine_data()
 
+# Load data from JSONL file at the beginning
+jsonl_data = load_jsonl_data()
 
-def generate_prompt(row, varieties):
-    # Format the varieties list as a comma-separated string
-    variety_list = ", ".join(varieties)
 
-    prompt = f"""
-    Based on this wine review, guess the grape variety:
-    This wine is produced by {row['winery']} in the {row['province']} region of {row['country']}.
-    It was grown in {row['region_1']}. It is described as: "{row['description']}".
-    The wine has been reviewed by {row['taster_name']} and received {row['points']} points.
-    The price is {row['price']}.
+def generate_prompt(index):
+    """Generates a prompt using the entry at the given index from the loaded JSONL data."""
+    if not jsonl_data:
+        raise ValueError("JSONL data is not loaded or is empty.")
+    if index >= len(jsonl_data):
+        raise IndexError(f"Index {index} is out of bounds for JSONL data with length {len(jsonl_data)}.")
 
-    Here is a list of possible grape varieties to choose from: {variety_list}.
-    
-    What is the likely grape variety? Answer only with the grape variety name or blend from the list.
-    """
-    return prompt
+    entry = jsonl_data[index]
+    if "prompt" not in entry:
+        raise KeyError(f"Key 'prompt' not found in JSONL data at index {index}.")
+
+    return entry["prompt"]
 
 
 # Function to call the API and process the result for a single model (blocking call in this case)

--- a/providers/wine_openrouter.py
+++ b/providers/wine_openrouter.py
@@ -9,6 +9,33 @@ import concurrent.futures
 from data_utils import prepare_wine_data
 from config import COUNTRY, SAMPLE_SIZE, RANDOM_SEED
 
+# Global variable to store data from JSONL file
+jsonl_data = []
+
+# Function to load data from JSONL file
+def load_jsonl_data(file_path="./train/data/test.jsonl"):
+    data = []
+    try:
+        with open(file_path, 'r') as f:
+            for line in f:
+                try:
+                    data.append(json.loads(line))
+                except json.JSONDecodeError as e:
+                    print(
+                        f"Warning: Skipping malformed JSON line in {file_path}: {line.strip()} - Error: {e}"
+                    )
+        if not data:
+            print(
+                f"Warning: No data loaded from {file_path}. File might be empty or all lines were malformed."
+            )
+        return data
+    except FileNotFoundError:
+        print(f"Error: {file_path} not found. Please ensure the file exists in the correct location.")
+        return []  # Return empty list if file not found
+    except Exception as e:
+        print(f"An unexpected error occurred while loading {file_path}: {e}")
+        return []
+
 # Define default models
 DEFAULT_MODELS = ["deepseek/deepseek-chat"]
 
@@ -21,23 +48,22 @@ np.random.seed(RANDOM_SEED)
 # Load and prepare the dataset
 df_country_subset, varieties = prepare_wine_data()
 
+# Load data from JSONL file at the beginning
+jsonl_data = load_jsonl_data()
 
-def generate_prompt(row, varieties):
-    # Format the varieties list as a comma-separated string
-    variety_list = ", ".join(varieties)
 
-    prompt = f"""
-    Based on this wine review, guess the grape variety:
-    This wine is produced by {row['winery']} in the {row['province']} region of {row['country']}.
-    It was grown in {row['region_1']}. It is described as: "{row['description']}".
-    The wine has been reviewed by {row['taster_name']} and received {row['points']} points.
-    The price is {row['price']}.
+def generate_prompt(index):
+    """Generates a prompt using the entry at the given index from the loaded JSONL data."""
+    if not jsonl_data:
+        raise ValueError("JSONL data is not loaded or is empty.")
+    if index >= len(jsonl_data):
+        raise IndexError(f"Index {index} is out of bounds for JSONL data with length {len(jsonl_data)}.")
 
-    Here is a list of possible grape varieties to choose from: {variety_list}.
-    
-    What is the likely grape variety? Answer only with the grape variety name or blend from the list.
-    """
-    return prompt
+    entry = jsonl_data[index]
+    if "prompt" not in entry:
+        raise KeyError(f"Key 'prompt' not found in JSONL data at index {index}.")
+
+    return entry["prompt"]
 
 
 response_format = {


### PR DESCRIPTION
## Summary
- standardize prompt generation across provider modules

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*